### PR TITLE
fix: add extra property to disable exposing URIs for all repos

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     import: "sm://"
   application:
     name: career-board
+  data:
+    rest:
+      detection-strategy: annotated
+      base-path: /api
   datasource:
     url: jdbc:postgresql:///career-board
     username: career-board


### PR DESCRIPTION
### Description
The issue with the endpoints was related to Spring Data REST. By default it exposes all endpoints including repository endpoints for all crud operations. I added some extra properties in application.yml to (1) change the base URL from '/' to '/api' and also change default behavior - only annotated repositories will be included in the endpoint output

### Story
Iteration: https://github.com/orgs/career-crew/projects/1

Story: https://github.com/orgs/career-crew/projects/1/views/1?pane=issue&itemId=64595470

### PR category:
- [x] Bug Fixes
- [ ] Partial Implementation
- [ ] Complete Implementation
- [ ] Refactor
- [ ] Experiment
- [ ] Pipeline trigger

### Reviewer Checklist
- [ ] PR title/description contains id or link of the Story
- [ ] Tests are created, and new code is covered
- [ ] PR checks, including SonarCloud, are successful
- [ ] ReadMe and other documents are updated
- [ ] No confidential information is committed
- [ ] Code modifications are reviewed and follow [guidelines](https://google.github.io/eng-practices/review/reviewer/)
- [ ] Changes meet story acceptance criteria
- [ ] Adheres to [java coding style guidelines](https://google.github.io/styleguide/javaguide.html)